### PR TITLE
Reset the textArea height after setValue().

### DIFF
--- a/com.imobicloud.textarea/controllers/widget.js
+++ b/com.imobicloud.textarea/controllers/widget.js
@@ -81,7 +81,7 @@ exports.setValue = function(value) {
             $.hint.show();
         }
     }
-    
+        textareaChange($.textarea);
 	return $.textarea.value = value;
 };
 


### PR DESCRIPTION
This resets the textArea height after setting a value that is less than the original value.
For example, when you have lots of text in the box and the height is greater than the original textArea height, if you use `setValue('');` it empties the textArea but its height remains.
This also works the opposite way if your setting lots of data into the textArea it will grow.